### PR TITLE
Change TLB to use a hash table instead of a ring buffer

### DIFF
--- a/cpu.h
+++ b/cpu.h
@@ -16,6 +16,7 @@ struct TLBEntry {
 // simple hash table to store TLB entries
 struct TLBStruct {
   int8_t max_entry_size;
+  uint8_t size_count[6]; // count number of entries for each size
   TLBEntry tlb_entries[TLB_SIZE];
 };
 

--- a/cpu.h
+++ b/cpu.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-constexpr uint16_t TLB_SIZE = 16;
+constexpr uint16_t TLB_SIZE = 64;
 
 struct TLBEntry {
   uint64_t virt_page;
@@ -13,9 +13,9 @@ struct TLBEntry {
   uint8_t permissions;
   bool user;
 };
-// simple ring buffer
+// simple hash table to store TLB entries
 struct TLBStruct {
-  uint16_t next_entry;
+  int8_t max_entry_size;
   TLBEntry tlb_entries[TLB_SIZE];
 };
 

--- a/mem.cpp
+++ b/mem.cpp
@@ -376,9 +376,17 @@ uint64_t tlb_find(HartState& hs, uint64_t virt_addr, uint8_t perms) {
 // hash table of TLB entries
 void tlb_add(TLBStruct &tlb, TLBEntry tlb_entry) {
   uint64_t index = tlb_hash(tlb_entry.virt_page);
-  if (tlb_entry.size > tlb.max_entry_size) {
-    tlb.max_entry_size = tlb_entry.size; // update max entry size if needed
+
+  TLBEntry old_entry = tlb.tlb_entries[index];
+  if (old_entry.permissions != 0) { // we are replacing a valid entry
+    tlb.size_count[old_entry.size] -= 1;
   }
+  tlb.size_count[tlb_entry.size] += 1;
+  tlb.max_entry_size = 0;
+  for (uint8_t i = 0; i < 6 ; i++) {
+    if (tlb.size_count[i] > 0) tlb.max_entry_size = i;
+  }
+
   tlb.tlb_entries[index] = tlb_entry; // add entry to hash table
 }
 

--- a/mem.h
+++ b/mem.h
@@ -78,6 +78,7 @@ void dump_mem();
 
 // TLB handling functions
 void tlb_clear(TLBStruct *tlb);
+uint16_t tlb_hash(uint64_t addr);
 uint64_t tlb_find(HartState& hs, uint64_t virt_addr, uint8_t perms);
 void tlb_add(TLBStruct &tlb, TLBEntry tlb_entry);
 


### PR DESCRIPTION
Currently, the TLB uses a ring buffer to store the entries. While this allows efficient adding of the entries, and also purges the oldest entry first, this causes the time complexity of the TLB checking to be linear in the size of the buffer. This PR changes it to use a hash table instead, so the accesses to the TLB become constant time.